### PR TITLE
fix error: [Unable to preventDefault]

### DIFF
--- a/www/static/assets/plugins/smoothscroll.js
+++ b/www/static/assets/plugins/smoothscroll.js
@@ -556,7 +556,7 @@
 			}
 
 			addEvent("mousedown", mousedown);
-			addEvent("mousewheel", wheel);
+			addEvent("mousewheel", wheel, {passive: false});
 			addEvent("load", init);
 
 		}


### PR DESCRIPTION
### 最近发现有个错误（如下）只要一滚动就会报，查了下google得到了[解决方案](https://developers.google.com/web/updates/2017/01/scrolling-intervention)
##### `[Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive. See https://www.chromestatus.com/features/6662647093133312`
